### PR TITLE
Match NPCI and RBI lists

### DIFF
--- a/tests/php/CoverageTest.php
+++ b/tests/php/CoverageTest.php
@@ -125,4 +125,21 @@ class CoverageTest extends TestCase
         $this->assertCount(0, $failures);
     }
 
+    /**
+     * This checks the `banks.json` file (generated from NPCI Data) against our validation
+     * which is based on RBI data.
+     */
+    public function testNpciListAgainstRbi()
+    {
+        $failures = [];
+        foreach ($this->bankList as $code => $data) {
+            $ifsc = $data['ifsc'];
+            if (strlen($ifsc) === 11 and IFSC::validate($ifsc) !== true)
+            {
+                $failures[] = $ifsc;
+            }
+        }
+
+        $this->assertEquals([], $failures, "IFSC codes present in NPCI, but missing in RBI lists");
+    }
 }


### PR DESCRIPTION
These are IFSC codes present in the NPCI list:
  https://www.npci.org.in/national-automated-clearing-live-members-1
but missing on the RBI list: https://www.rbi.org.in/Scripts/bs_viewcontent.aspx?Id=2009

The RBI is our primary source of truth, so this is just bonkers.

_Update_: Reached out to RBI regarding this