### PR TITLE
Release/2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED][unreleased]
 
+## [2.0.3][2.0.3]
+## Changed
+- Adds back 20 IFSC codes removed due to a change on the RBI sheet structure in 2.0.2
+
 ## [2.0.2][2.0.2]
 ## Changed
 - Metadata changes
@@ -227,7 +231,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Removes some data formats (YAML/Large JSON) for cleaner code. If you were using them, please let create an issue.
 
-[unreleased]: https://github.com/razorpay/ifsc/compare/2.0.2...HEAD
+[unreleased]: https://github.com/razorpay/ifsc/compare/2.0.3...HEAD
+[2.0.3]: https://github.com/razorpay/ifsc/releases/tag/2.0.3
 [2.0.2]: https://github.com/razorpay/ifsc/releases/tag/2.0.2
 [2.0.1]: https://github.com/razorpay/ifsc/releases/tag/2.0.1
 [2.0.0]: https://github.com/razorpay/ifsc/releases/tag/2.0.0

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is part of the IFSC toolset released by Razorpay.
 You can find more details about the entire release at
 [ifsc.razorpay.com](https://ifsc.razorpay.com).
 
-[![](https://images.microbadger.com/badges/image/razorpay/ifsc:2.0.2.svg)](https://microbadger.com/images/razorpay/ifsc:2.0.2) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+[![](https://images.microbadger.com/badges/image/razorpay/ifsc:2.0.3.svg)](https://microbadger.com/images/razorpay/ifsc:2.0.3) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-[![](https://images.microbadger.com/badges/version/razorpay/ifsc:2.0.2.svg)](https://microbadger.com/images/razorpay/ifsc:2.0.2) [![npm version](https://badge.fury.io/js/ifsc.svg)](https://badge.fury.io/js/ifsc) [![Gem Version](https://badge.fury.io/rb/ifsc.svg)](https://badge.fury.io/rb/ifsc) [![PHP version](https://badge.fury.io/ph/razorpay%2Fifsc.svg)](https://badge.fury.io/ph/razorpay%2Fifsc) [![Hex pm](http://img.shields.io/hexpm/v/ifsc.svg)](https://hex.pm/packages/ifsc)
+[![](https://images.microbadger.com/badges/version/razorpay/ifsc:2.0.3.svg)](https://microbadger.com/images/razorpay/ifsc:2.0.3) [![npm version](https://badge.fury.io/js/ifsc.svg)](https://badge.fury.io/js/ifsc) [![Gem Version](https://badge.fury.io/rb/ifsc.svg)](https://badge.fury.io/rb/ifsc) [![PHP version](https://badge.fury.io/ph/razorpay%2Fifsc.svg)](https://badge.fury.io/ph/razorpay%2Fifsc) [![Hex pm](http://img.shields.io/hexpm/v/ifsc.svg)](https://hex.pm/packages/ifsc)
 
 ## Dataset
 

--- a/ifsc.gemspec
+++ b/ifsc.gemspec
@@ -3,8 +3,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'ifsc'
-  s.version     = '2.0.2'
-  s.date        = '2021-11-16'
+  s.version     = '2.0.3'
+  s.date        = '2021-11-17'
   s.summary     = 'IFSC code database to help you validate IFSC codes'
   s.description = 'A simple gem by @razorpay to help you validate your IFSC codes. IFSC codes are bank codes within India'
   s.authors     = ['Abhay Rana', 'Nihal Gonsalves']

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "ifsc",
-  "version": "1.5.7",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16,9 +16,9 @@
       }
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -39,9 +39,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -200,16 +200,16 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.51.0"
       }
     },
     "oauth-sign": {
@@ -313,9 +313,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifsc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "This is part of the IFSC toolset released by Razorpay. You can find more details about the entire release at [ifsc.razorpay.com](https://ifsc.razorpay.com). Includes only a validation library as of now.",
   "main": "src/node/index.js",
   "directories": {

--- a/scraper/scripts/generate.rb
+++ b/scraper/scripts/generate.rb
@@ -11,7 +11,7 @@ imps = parse_imps(banks)
 log "[NPCI] Got #{imps.keys.size} entries"
 
 # The first sheet on RTGS gives summary numbers, which we ignore
-rtgs = parse_csv(['RTGS-1', 'RTGS-2'], banks, {"RTGS"=> true})
+rtgs = parse_csv(['RTGS-1', 'RTGS-2', 'RTGS-3'], banks, {"RTGS"=> true})
 log "[RTGS] Got #{rtgs.keys.size} entries"
 
 neft = parse_csv(['NEFT-0', 'NEFT-1'], banks, {"NEFT"=> true})


### PR DESCRIPTION
**Release Date**: `2021-11-17`
**RBI Update Date**: `2021-11-01`
**IFSC Count**: 159447
**Diff Size**: 20 (This only counts new or deleted IFSCs from previous release)

- 20 IFSCs were missed in the previous release due to a change on the RBI side that went un-detected. This release adds them back. 
- The dataset also fixes some additional fields for 50,000+ IFSCs (mainly MICR codes, but can also be contact details or address).

<details><summary><strong>Aggregate Breakdown</strong>
</summary>

```
+1  	SBLS
+1  	SECB
+1  	SIBL
+1  	SIDC
+1  	SNBK
+1  	STCB
+1  	TBMC
+1  	TMSB
+1  	TNCB
+1  	TNSC
+1  	TPSC
+1  	UTIB
+2  	SBIN
+6  	UBIN
```
</details>

<details><summary><strong>Exact IFSC Diff</strong></summary>

```diff
+SBIN0030441
+SBIN0030444
+SBLS00000SC
+SECB0000001
+SIBL0RTGSCL
+SIDC0000001
+SNBK0000001
+STCB0000001
+TBMC0000001
+TMSB0000001
+TNCB0000001
+TNSC0NEFTSC
+TPSC00000SC
+UBIN0904783
+UBIN0906930
+UBIN0907421
+UBIN0908444
+UBIN0918717
+UBIN0997455
+UTIB0000001
```
</details>


Here is a cute longhorn beetle:

![erik-karits-j5qHa9sEEOw-unsplash](https://user-images.githubusercontent.com/584253/142178567-260227de-eee0-4ea6-b86e-de35419a8ba5.jpg)