### PR TITLE
fixed branch name - ICIC0000204

### DIFF
--- a/src/patches/ifsc/ICIC0000204.yml
+++ b/src/patches/ifsc/ICIC0000204.yml
@@ -1,0 +1,10 @@
+---
+# Data is incorrect in RBI NEFT sheet
+# There is a typo with the branch name with the RBI sheet
+# Correct data comes from the ICICI Branch Locator
+# https://www.icicibank.com/branch/karnataka/bangalore/icic0000204
+action: patch
+patch:
+  BRANCH: BANGALORE R T NAGAR
+ifsc:
+  - ICIC0000204


### PR DESCRIPTION
The branch name for the IFSC - `ICIC0000204` - has a typo in the RBI NEFT Sheet - `BANGALORER T NAGAR"`
Please check the attached image below:

![image](https://github.com/razorpay/ifsc/assets/14135553/380150c9-038a-43ff-a578-9403a0532426)

But as per the official ICICI website, it should be `BANGALORE R T NAGAR`
Please check the link attached below:
https://www.icicibank.com/branch/karnataka/bangalore/icic0000204
<img width="1552" alt="image" src="https://github.com/razorpay/ifsc/assets/14135553/5d35df2a-f75a-4a1d-97ec-63f33ba4f155">
