### PR TITLE
chore: update go version and migrate from io/ioutil to io

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/razorpay/ifsc/v2
 
-go 1.18
+go 1.23.2
 
 require github.com/stretchr/testify v1.8.0
 
@@ -9,3 +9,4 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/src/go/bank.go
+++ b/src/go/bank.go
@@ -17,7 +17,7 @@ type Bank struct {
 	AchCredit bool   `json:"ach_credit"`
 	AchDebit  bool   `json:"ach_debit"`
 	NachDebit bool   `json:"nach_debit"`
-	Upi       bool   `json:"upi",omitempty`
+	Upi       bool   `json:"upi,omitempty"`
 }
 
 var bankData map[string]Bank
@@ -45,3 +45,4 @@ func GetBankDetails(bankCode string) *Bank {
 	}
 	return &data
 }
+

--- a/src/go/client.go
+++ b/src/go/client.go
@@ -2,7 +2,7 @@ package ifsc
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
@@ -47,7 +47,7 @@ func LookUP(ifsc string) (*IFSCResponse, error) {
 	}
 	status := resp.StatusCode
 	if status == http.StatusOK {
-		responseBytes, err := ioutil.ReadAll(resp.Body)
+		responseBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -118,3 +118,4 @@ func (ifsc *IFSCResponse) GetBankName() string {
 	}
 	return bankName
 }
+

--- a/src/go/client_test.go
+++ b/src/go/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -157,7 +157,7 @@ func GetSuccessMockResponse() {
 			"BANKCODE":"HDFC",
 			"IFSC":"HDFC0CAGSBK"
 		}`
-		r := ioutil.NopCloser(bytes.NewReader([]byte(successJson)))
+		r := io.NopCloser(bytes.NewReader([]byte(successJson)))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       r,
@@ -217,3 +217,4 @@ func TestIFSCResponse_GetBankName(t *testing.T) {
 		})
 	}
 }
+

--- a/src/go/generator/main.go
+++ b/src/go/generator/main.go
@@ -1,24 +1,21 @@
 package main
 
 import ( // nosemgrep go.lang.security.audit.xss.import-text-template.import-text-template
+	"encoding/json"
 	"fmt"
-	"text/template"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
-	"encoding/json"
+	"text/template"
 )
-
 
 type bankConstants struct {
 	Value []string
 }
 
-
-func GetConstants() (*bankConstants) {
-	jsonString, _ := ioutil.ReadFile("src/banknames.json")
+func GetConstants() *bankConstants {
+	jsonString, _ := os.ReadFile("src/banknames.json")
 	var result bankConstants
 	var data map[string]interface{}
 	json.Unmarshal([]byte(jsonString), &data)
@@ -30,14 +27,14 @@ func GetConstants() (*bankConstants) {
 
 	sort.Strings(keys)
 
-	for _,k := range keys {
+	for _, k := range keys {
 		result.Value = append(result.Value, k)
 	}
 	return &result
 }
 
 func GenerateConstantsFile(outputFileWriter io.Writer, templateFilePath string, constantsArr *bankConstants) error {
-	fileBytes, err := ioutil.ReadFile(templateFilePath)
+	fileBytes, err := os.ReadFile(templateFilePath)
 	if err != nil {
 		return err
 	}
@@ -63,3 +60,4 @@ func main() {
 	}
 	fmt.Printf("Updated %v \n", outputFilePath)
 }
+

--- a/src/go/ifsc.go
+++ b/src/go/ifsc.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"runtime"
 	"strconv"
@@ -77,7 +77,7 @@ func LoadFile(fileName string, result interface{}, fullDirPath string) error {
 		completePath = path.Join(jsonDir, fileName)
 
 	}
-	bytes, err := ioutil.ReadFile(completePath)
+	bytes, err := os.ReadFile(completePath)
 	if err != nil {
 		return err
 	}
@@ -165,3 +165,4 @@ func ValidateBankCode(bankCodeInput string) bool {
 	_, ok := bankCodes[bankCodeInput]
 	return ok
 }
+

--- a/src/go/ifsc_test.go
+++ b/src/go/ifsc_test.go
@@ -16,7 +16,7 @@ func TestGetBankName_BankName(t *testing.T) {
 func TestGetBankName_Sublet(t *testing.T) {
 	assert := assert.New(t)
 	fixtureData := getSubletFixture()
-	for input, _ := range fixtureData {
+	for input := range fixtureData {
 		ownerBankCode := input[0:4]
 		actual, err := GetBankName(input)
 		assert.Nil(err)
@@ -117,3 +117,4 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
Updated go version to 1.23.2 ensuring compatibility with new features and improvements. Additionally, I have replaced deprecated io/ioutil package usages with the appropriate functions from the io and os packages