### PR TITLE
feat(node): add typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ifsc",
-  "version": "2.0.11",
+  "version": "2.0.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ifsc",
-      "version": "2.0.11",
+      "version": "2.0.59",
       "license": "MIT",
       "dependencies": {
         "request": "^2.88.2"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.59",
   "description": "This is part of the IFSC toolset released by Razorpay. You can find more details about the entire release at [ifsc.razorpay.com](https://ifsc.razorpay.com). Includes only a validation library as of now.",
   "main": "src/node/index.js",
+  "types": "src/node/index.d.ts",
   "directories": {
     "test": "tests"
   },

--- a/src/node/bank.d.ts
+++ b/src/node/bank.d.ts
@@ -1,0 +1,2 @@
+declare const BANK: Readonly<Record<string, string>>;
+export = BANK;

--- a/src/node/index.d.ts
+++ b/src/node/index.d.ts
@@ -1,0 +1,27 @@
+declare namespace IFSC {
+  interface IFSCDetails {
+    IFSC: string;
+    BANK: string;
+    BANKCODE: string;
+    BRANCH: string;
+    ADDRESS: string;
+    CITY: string;
+    CENTRE: string;
+    DISTRICT: string;
+    STATE: string;
+    ISO3166: string;
+    CONTACT: string | null;
+    MICR: string | null;
+    SWIFT: string | null;
+    NEFT: boolean;
+    RTGS: boolean;
+    IMPS: boolean;
+    UPI: boolean;
+  }
+
+  function validate(code: string): boolean;
+  function fetchDetails(code: string): Promise<IFSCDetails>;
+  const bank: Readonly<Record<string, string>>;
+}
+
+export = IFSC;


### PR DESCRIPTION
Adds `.d.ts` type declaration files for the Node.js package so TypeScript users get type checking and IDE autocompletion out of the box after installing via npm/yarn — no separate `@types/` package needed.

## Changes

- `src/node/index.d.ts` — types for `validate`, `fetchDetails`, and `bank`; includes `IFSCDetails` interface matching the API response shape
- `src/node/bank.d.ts` — types for the generated bank constants object
- `package.json` — adds `"types"` field pointing to `index.d.ts`

## Notes

Uses the `export =` + namespace pattern so it works regardless of whether the consumer has `esModuleInterop` enabled in their `tsconfig.json`.

No runtime changes. Existing tests pass.