### PR TITLE
Upgrade Go to 1.25

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
   go:
     strategy:
       matrix:
-        go: ["^1.17.0", "^1.18.0", "^1.19.0"]
+        go: ["^1.25.0", "^1.26.0"]
     name: Go
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/razorpay/ifsc/v2
 
-go 1.18
+go 1.25
 
 require github.com/stretchr/testify v1.8.0
 

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Part of the org Go N-1 migration (pilot for the automated go-upgrade flow).

- Bumps the `go` directive 1.18 → 1.25; `go mod tidy` recorded the existing check.v1 test dep.
- CI Go matrix updated ^1.17–^1.19 → ^1.25/^1.26 (toolchains below the module directive cannot build it).
- Local `go build ./...` green. Note: `TestLookUP` panics on a clean master checkout too (pre-existing, unrelated); CI's constants check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)