### PR TITLE
feat(node): add sublet bank branch lookup support (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Only the latest version of each SDK is considered.
 | -------- | ---------- | ---------- | ----------------------- | -------------- |
 | PHP      | ✅         | ✅         | ✅ (✅)                 | ✅             |
 | Ruby     | ✅         | ✅         | ✅ (✅)                 | ✅             |
-| Node.js  | ✅         | ✅         | ❎ (❎)                 | ✅             |
+| Node.js  | ✅         | ✅         | ✅ (✅)                 | ✅             |
 | Go       | ✅         | ✅         | ✅ (✅)                 | ✅             |
 
 ## API Documentation
@@ -198,6 +198,14 @@ var ifsc = require('ifsc');
 
 ifsc.validate('KKBK0000261'); // returns true
 ifsc.validate('BOTM0XEEMRA'); // returns false
+
+ifsc.validateBankCode('PUNB'); // returns true
+ifsc.validateBankCode('ABCD'); // returns false
+
+ifsc.getBankName('PUNB'); // returns 'Punjab National Bank'
+ifsc.getBankName('WBSC0DJCB01'); // returns 'Darjeeling District Central Co-operative Bank'
+ifsc.getBankName('KSCB0006001'); // returns 'Tumkur District Central Bank'
+ifsc.getBankName('ABCD'); // returns null
 
 ifsc.fetchDetails('KKBK0000261').then(function(res) {
    console.log(res);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ifsc",
-  "version": "2.0.11",
+  "version": "2.0.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ifsc",
-      "version": "2.0.11",
+      "version": "2.0.61",
       "license": "MIT",
       "dependencies": {
         "request": "^2.88.2"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "node tests/node/validator_test.js && node tests/node/client_test.js && node tests/node/bank_test.js"
+    "test": "node tests/node/validator_test.js && node tests/node/client_test.js && node tests/node/bank_test.js && node tests/node/sublet_test.js"
   },
   "repository": {
     "type": "git",

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 const data = require('../IFSC');
+const bankNames = require('../banknames.json');
+const sublets = require('../sublet.json');
+const customSublets = require('../custom-sublets.json');
+const customSubletPrefixes = Object.keys(customSublets);
 const https = require('https');
 const request = require('request');
 const BANK = require('./bank');
@@ -7,7 +11,7 @@ const BANK = require('./bank');
 const BASE_URL = 'https://ifsc.razorpay.com/';
 
 let _validate = function(code) {
-  if (code.length !== 11) {
+  if (!code || typeof code !== 'string' || code.length !== 11) {
     return false;
   }
 
@@ -29,6 +33,57 @@ let _validate = function(code) {
   }
 
   return lookupString(list, branchCode);
+};
+
+let _validateBankCode = function(bankCode) {
+  if (!bankCode || typeof bankCode !== 'string') {
+    return false;
+  }
+  bankCode = bankCode.toUpperCase();
+  return BANK.hasOwnProperty(bankCode) || bankNames.hasOwnProperty(bankCode);
+};
+
+let _getCustomSubletName = function(code) {
+  for (let i = 0; i < customSubletPrefixes.length; i++) {
+    let prefix = customSubletPrefixes[i];
+    if (code.startsWith(prefix)) {
+      let value = customSublets[prefix];
+      if (value.length === 4) {
+        return _getBankName(value);
+      } else {
+        return value;
+      }
+    }
+  }
+  return null;
+};
+
+let _getBankName = function(code) {
+  if (!code || typeof code !== 'string') {
+    return null;
+  }
+  code = code.toUpperCase();
+
+  if (_validateBankCode(code)) {
+    return bankNames[code] || null;
+  }
+
+  if (_validate(code)) {
+    if (sublets.hasOwnProperty(code)) {
+      let bankCode = sublets[code];
+      return bankNames[bankCode] || null;
+    }
+
+    let customSubletName = _getCustomSubletName(code);
+    if (customSubletName) {
+      return customSubletName;
+    }
+
+    let ownerBankCode = code.slice(0, 4);
+    return bankNames[ownerBankCode] || null;
+  }
+
+  return null;
 };
 
 let isInteger = function(code) {
@@ -73,6 +128,8 @@ let _fetchDetails = function(code, cb) {
 
 module.exports = {
   validate: _validate,
+  validateBankCode: _validateBankCode,
+  getBankName: _getBankName,
   fetchDetails: _fetchDetails,
   bank: BANK,
 };

--- a/tests/node/bank_test.js
+++ b/tests/node/bank_test.js
@@ -13,4 +13,6 @@ let valid_bank_keys = Object.keys(JSON.parse(fs
 valid_bank_keys.forEach(code => {
   assert.equal(BANK[code], code);
   assert.equal(IFSC.bank[code], code);
+  assert.equal(IFSC.validateBankCode(code), true);
+  assert.ok(IFSC.getBankName(code));
 });

--- a/tests/node/sublet_test.js
+++ b/tests/node/sublet_test.js
@@ -1,0 +1,32 @@
+const ifsc = require('../../src/node');
+const assert = require('assert');
+
+// 1. Basic bank name lookup by 4-letter bank code
+assert.equal(ifsc.getBankName('PUNB'), 'Punjab National Bank');
+assert.equal(ifsc.getBankName(ifsc.bank.PUNB), 'Punjab National Bank');
+
+// 2. Bank name lookup by regular IFSC code
+assert.equal(ifsc.getBankName('KKBK0000261'), 'Kotak Mahindra Bank');
+
+// 3. Sublet lookup by IFSC code
+assert.equal(ifsc.getBankName('WBSC0DJCB01'), 'Darjeeling District Central Co-operative Bank');
+assert.equal(ifsc.getBankName('XNSE0000001'), 'NSE Clearing Limited');
+
+// 4. Custom sublets lookup by prefix
+assert.equal(ifsc.getBankName('KSCB0006001'), 'Tumkur District Central Bank');
+assert.equal(ifsc.getBankName('WBSC0KPCB01'), 'Kolkata Police Co-operative Bank');
+assert.equal(ifsc.getBankName('YESB0ADB002'), 'Amravati District Central Co-operative Bank');
+
+// 5. Invalid bank code / IFSC handling
+assert.equal(ifsc.getBankName('ABCD'), null);
+assert.equal(ifsc.getBankName('BOTM0XEEMRA'), null);
+assert.equal(ifsc.getBankName(''), null);
+assert.equal(ifsc.getBankName(null), null);
+
+// 6. Bank code validation
+assert.equal(ifsc.validateBankCode('PUNB'), true);
+assert.equal(ifsc.validateBankCode('ABCD'), false);
+assert.equal(ifsc.validateBankCode(''), false);
+assert.equal(ifsc.validateBankCode(null), false);
+
+console.log('All Node.js sublet tests passed successfully!');


### PR DESCRIPTION
## Summary
Adds sublet bank branch lookup support (`getBankName` and `validateBankCode`) to the Node.js package, bringing Node.js feature parity with PHP, Ruby, and Go.

## Changes
- Implemented `getBankName(code)` and `validateBankCode(bankCode)` in `src/node/index.js`.
- Loaded `banknames.json`, `sublet.json`, and `custom-sublets.json` for resolving sublet branch IFSC codes to their respective sublet bank names.
- Added comprehensive unit tests in `tests/node/sublet_test.js` and updated `tests/node/bank_test.js`.
- Updated `package.json` test runner script to include `sublet_test.js`.
- Updated `README.md` support matrix and Node.js code examples.

Closes #169.