### PR TITLE
perf(go): remove JSON round trip from validation

### DIFF
--- a/src/go/ifsc.go
+++ b/src/go/ifsc.go
@@ -97,33 +97,21 @@ func Validate(code string) bool {
 	if !ok {
 		return false
 	}
-	branchData, err := getData(branchCode)
-	if err != nil {
-		return false
-	}
+	branchData := getData(branchCode)
 	for _, data := range list {
-		if data == *branchData {
+		if data == branchData {
 			return true
 		}
 	}
 	return false
 }
 
-func getData(input string) (*Data, error) {
-	var inputBytes []byte
-	var err error
+func getData(input string) Data {
 	intValue, err := strconv.ParseInt(input, 10, 32)
 	if err == nil {
 		input = strconv.Itoa(int(intValue))
 	}
-	if inputBytes, err = json.Marshal(input); err != nil {
-		return nil, err
-	}
-	var output Data
-	if err := json.Unmarshal(inputBytes, &output); err != nil {
-		return nil, err
-	}
-	return &output, nil
+	return Data{Value: input}
 }
 
 func GetBankName(code string) (string, error) {


### PR DESCRIPTION
## Summary

Remove the unnecessary JSON marshal/unmarshal round trip from the Go IFSC validation path.

`getData` now normalizes the branch suffix directly and returns a `Data` value instead of serializing and deserializing it.

## Why

The previous implementation performed JSON marshaling and unmarshaling during every validation call even though the input was already available as a string.

This change removes unnecessary serialization work and allocations while preserving existing validation behavior.

## Testing

- `go test ./src/go -run Validate -v` passes.
- `go test ./...` still hits the existing `TestLookUP/success` nil-pointer panic on unmodified `master`, so that failure is unrelated to this change.

## Test Case Document URL

Not added. The `Tested` label is not being used for this PR.